### PR TITLE
Semantic versioning and LooseVersion usage in zippero-server.

### DIFF
--- a/package_management/data_scanning.py
+++ b/package_management/data_scanning.py
@@ -1,5 +1,5 @@
 import os
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from typing import List, Dict
 
 import package_management.data_paths as data_paths
@@ -27,6 +27,6 @@ def scan_data_directory(data_dir_path: str) -> Dict[str, PackageInfo]:
                           packages_dict.items()}
 
     for k, info in package_info_dicts.items():
-        info.versions.sort(key=StrictVersion)
+        info.versions.sort(key=LooseVersion)
 
     return package_info_dicts

--- a/package_management/package_manager.py
+++ b/package_management/package_manager.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import shutil
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from threading import Lock
 from typing import List, Dict, Optional
 from zipfile import ZipFile
@@ -128,7 +128,7 @@ class PackageManager:
             package_infos_clone[name] = PackageInfo(name=name, versions=[])
 
         package_infos_clone[name].versions.append(version)
-        package_infos_clone[name].versions.sort(key=StrictVersion)
+        package_infos_clone[name].versions.sort(key=LooseVersion)
         self._package_infos = package_infos_clone
 
     def _remove_version_to_package_info(self, name, version):
@@ -138,7 +138,7 @@ class PackageManager:
             package_infos_clone[name] = PackageInfo(name=name, versions=[])
 
         package_infos_clone[name].versions.remove(version)
-        package_infos_clone[name].versions.sort(key=StrictVersion)
+        package_infos_clone[name].versions.sort(key=LooseVersion)
 
         if len(package_infos_clone[name].versions) == 0:
             del package_infos_clone[name]

--- a/package_management/package_validation.py
+++ b/package_management/package_validation.py
@@ -2,7 +2,9 @@ import re
 
 from errors.errors import InvalidNameError, InvalidVersionError
 
-version_regex = r'^[\.\d]+$'
+# Semantic versioning: https://semver.org/
+# https://regex101.com/r/Ly7O1x/3/
+version_regex = r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 name_regex = r'^[\w\.\-]+$'
 
 

--- a/package_management/package_validation.py
+++ b/package_management/package_validation.py
@@ -4,7 +4,7 @@ from errors.errors import InvalidNameError, InvalidVersionError
 
 # Semantic versioning: https://semver.org/
 # https://regex101.com/r/Ly7O1x/3/
-version_regex = r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+version_regex = r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.([0-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 name_regex = r'^[\w\.\-]+$'
 
 


### PR DESCRIPTION
Currently zippero is too strict when it comes to versions handling, and doesn't allow version like 5.15.1-beta+1234 to be used. This pull request fixes this issue.